### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,18 +10,18 @@ Euc	KEYWORD1
 # Methods and Functions 
 #######################################	
 
-tick	            KEYWORD2
-setCallback	    	KEYWORD2
-beep                KEYWORD2
-maddenMode          KEYWORD2
-comfortMode         KEYWORD2
-softMode            KEYWORD2
-calibrateAlignment  KEYWORD2
-disableLevel1Alarm  KEYWORD2
-disableLevel2Alarm  KEYWORD2
-enableAlarms        KEYWORD2
-enable6kmhTiltback  KEYWORD2
-disable6kmhTiltback KEYWORD2
+tick	KEYWORD2
+setCallback	KEYWORD2
+beep	KEYWORD2
+maddenMode	KEYWORD2
+comfortMode	KEYWORD2
+softMode	KEYWORD2
+calibrateAlignment	KEYWORD2
+disableLevel1Alarm	KEYWORD2
+disableLevel2Alarm	KEYWORD2
+enableAlarms	KEYWORD2
+enable6kmhTiltback	KEYWORD2
+disable6kmhTiltback	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords